### PR TITLE
Cleaned Funding Poll and made new create org page

### DIFF
--- a/fundingpoll/models.py
+++ b/fundingpoll/models.py
@@ -8,14 +8,6 @@ from finance.models import Budget, BudgetItem
 
 from fundingpoll.manager import FundingPollVoteManager
 
-BEFORE_R = "before_registration"
-DURING_R = "during_registration"
-BEFORE_V = "before_voting"
-DURING_V = "during_voting"
-BEFORE_B = "before_budgets"
-DURING_B = "during_budgets"
-END_B = "end_budgets"
-
 class FundingPoll(models.Model):
   start_registration = models.DateTimeField()
   end_registration = models.DateTimeField()
@@ -34,6 +26,10 @@ class FundingPoll(models.Model):
   def during_voting(self):
     today = datetime.now()
     return self.start_voting < today and today < self.end_voting
+
+  def after_voting(self):
+    today = datetime.now()
+    return self.end_voting < today
 
   def during_budgets(self):
     today = datetime.now()

--- a/fundingpoll/urls.py
+++ b/fundingpoll/urls.py
@@ -4,7 +4,6 @@ urlpatterns = patterns(
     'fundingpoll.views',
     (r'^$','index'),
   (r'^vote/?$','vote_main'),
-  (r'^vote2/?$','vote_main2'),
   (r'^vote/submit/?$','submit_vote'),
   (r'^my_registrations/?$', 'my_registrations'),
   (r'^my_registrations/save/?$','save_registration'),

--- a/fundingpoll/views.py
+++ b/fundingpoll/views.py
@@ -76,10 +76,6 @@ def index(request):
   authenticate(request, VALID_FACTORS)
   admin = request.user.has_factor(ADMIN_FACTORS)
  
-  ##############################
-  # BB on 1/12/14
-  # This is a mess. I hope I clean it up later
-  ##############################
   try:
     fp = get_fp()
     fp_exists = True
@@ -90,48 +86,28 @@ def index(request):
 
   has_org = (num_orgs > 0)
 
-  if fp_exists: 
-    if fp.during_registration():
-      reg_open = True
-      def get_org(o):
-        return o.organization
+  template_args = {
+    'admin': admin,
+    'num_orgs': num_orgs,
+    'has_org': has_org,
+    'reg_open': None
+  }
 
-      fp_reg_orgs = [o for o in fp.fundingpollorganization_set.filter(funding_poll = fp, organization__signator = request.user)]
-      reg_orgs = [get_org(o) for o in fp_reg_orgs]
-      unreg_orgs = filter(lambda o: o not in reg_orgs,request.user.signator_set.all())
+  if fp_exists and fp.during_registration():
+    template_args['reg_open'] = True
+    
+    def get_org(o):
+      return o.organization
 
-      if len(unreg_orgs) > 0:
-        fp_unreg = True
-      else:
-        fp_unreg = False
-
-      template_args = {
-        'admin' : admin,
-        'num_orgs': num_orgs,
-        'has_org': has_org,
-        'reg_open' : reg_open,
-        'need_to_reg' : fp_unreg 
-        }
-
-    else:
-      reg_open = False
-
-      template_args = {
-        'admin' : admin,
-        'num_orgs': num_orgs,
-        'has_org': has_org,
-        'reg_open' : reg_open,
-        }
-
+    fp_reg_orgs = [o for o in fp.fundingpollorganization_set.filter(funding_poll = fp, organization__signator = request.user)]
+    reg_orgs = [get_org(o) for o in fp_reg_orgs]
+    unreg_orgs = filter(lambda o: o not in reg_orgs,request.user.signator_set.all())
+    fp_unreg = len(unreg_orgs) > 0
+    template_args['need_to_reg'] = fp_unreg
   else:
-    template_args = {
-      'admin': admin,
-      'num_orgs': num_orgs,
-      'has_org': has_org,
-      'reg_open' : False,
-      }
+    template_args['reg_open'] = False
 
-  return render_to_response('fundingpoll/index.html', template_args, context_instance=RequestContext(request))
+  return render(request, 'fundingpoll/index.html', template_args)
 
 def decamelcase(s):
   i = s.index('_')
@@ -154,7 +130,7 @@ def schedule(request):
     'time' : current_time
   }
   
-  return render_to_response('fundingpoll/schedule.html', template_args, context_instance=RequestContext(request))
+  return render(request, 'fundingpoll/schedule.html', template_args)
 
 def registered(request):
   authenticate(request, VALID_FACTORS)
@@ -166,46 +142,15 @@ def registered(request):
     'forgs' : forgs
   }
 
-  return render_to_response('fundingpoll/registered.html', template_args, context_instance=RequestContext(request))
-
-def vote_main2(request):
-  admin = ('admin' == authenticate(request, VALID_FACTORS))
-  
-  fp = get_fp()
-  
-#  if not check_status(fp,[DURING_V]):
-#    raise PermissionDenied
-
-  if check_status(fp,[DURING_V]):
-    if not os.access(a,os.F_OK) or b:
-      def refresh_dump():
-        from django.template.loader import render_to_string
-        from webapps.settings import TEMPLATE_DIRS
-        import codecs
-        template_args = {
-          'forgs' : fp.fundingpollorganization_set.order_by('?')
-        }
-        target = os.path.join(TEMPLATE_DIRS[0],'fundingpoll/vote_dump.phtml')
-        f = codecs.open(target,'w','utf-8')
-        f.write(render_to_string('fundingpoll/vote_main.html'),template_args)
-        f.close()
-      refresh_dump()
-    return render_to_response('fundingpoll/vote_dump.phtml', context_instance=RequestContext(request))
-  else:
-    forgs = fp.fundingpollorganization_set.order_by('ordering')
-    
-    template_args = {
-      'forgs' : forgs
-    }
-    
-    return render_to_response('fundingpoll/vote_dump.phtml',template_args, context_instance=RequestContext(request))
+  return render(request, 'fundingpoll/registered.html', template_args)
 
 def vote_main(request):
-  admin = ('admin' == authenticate(request, VALID_FACTORS))
+  authenticate(request, VALID_FACTORS)
+  admin = request.user.has_factor(ADMIN_FACTORS)
   
   fp = get_fp()
   
-  if not check_status(fp, [DURING_V]): #and not admin:
+  if not fp.during_voting() and not admin:
     raise PermissionDenied
 
   # Check if they have already voted
@@ -213,7 +158,10 @@ def vote_main(request):
                                      funding_poll = fp)
   if vote_set.exists():
     r = HttpResponseForbidden()
-    r.write('<p>Error, you may not vote twice in fundingpoll.</p>')
+    r.write('''
+    <h1>Sorry</h1>
+    <p>You may not vote twice in Funding Poll.</p>
+    ''')
     return r
     
   
@@ -223,8 +171,8 @@ def vote_main(request):
     'forgs' : forgs
   }
   
-  return render_to_response('fundingpoll/vote_main.html', template_args, context_instance=RequestContext(request))
-  #return render_to_response('fundingpoll/vote_dump.phtml', context_instance=RequestContext(request))
+  return render(request, 'fundingpoll/vote_main.html', template_args)
+
 
 def admin_voting(request):
   authenticate(request, ADMIN_FACTORS)
@@ -237,18 +185,18 @@ def admin_voting(request):
     'forgs' : forgs
   }
   
-  return render_to_response('fundingpoll/vote_main.html', template_args, context_instance=RequestContext(request))
+  return render(request, 'fundingpoll/vote_main.html', template_args)
 
 def submit_vote(request):
   authenticate(request, VALID_FACTORS)
-  admin = ('admin' == authenticate(request, VALID_FACTORS))
+  admin = request.user.has_factor(ADMIN_FACTORS)
   
   if request.method != 'POST':
     raise Http404()
   
   fp = get_fp()
   
-  if not check_status(fp,DURING_V) and not admin:
+  if not fp.during_voting() and not admin:
     raise PermissionDenied
   
   d = request.POST
@@ -264,7 +212,7 @@ def submit_vote(request):
       r.write('<p>Error, you may not vote twice in fundingpoll.</p>')
       return r
   
-  return render_to_response('fundingpoll/voting_success.html', context_instance=RequestContext(request))
+  return render(request, 'fundingpoll/voting_success.html')
 
 def organize_orgs(request):
   authenticate(request, ADMIN_FACTORS)
@@ -317,11 +265,13 @@ def top_40_emails(request):
 
 def my_registrations(request):
   authenticate(request, VALID_FACTORS)
-  admin = request.user.has_factor(['fundingpoll', 'admin'])
+  admin = request.user.has_factor(ADMIN_FACTORS)
   
   fp = get_fp()
+
+  current_fp = fp.during_registration() or fp.during_voting() or fp.during_budgets()
   
-  if not check_status(fp,[DURING_R, DURING_B, DURING_V]) and not admin:
+  if not current_fp  and not admin:
     raise PermissionDenied
   
   if request.user.attended_signator_training == False:
@@ -329,19 +279,11 @@ def my_registrations(request):
       'title' : 'Error!',
       'message' : 'You cannot register an organization because you have not attended Signator Training.',
       'redirect' : reverse('fundingpoll.views.index')
-      #'redirect' : '/webapps/fundingpoll',
     }
-    return render_to_response('generic/alert-redirect.phtml', template_args, context_instance=RequestContext(request))
+    return render(request, 'generic/alert-redirect.phtml', template_args)
   
-  #if False and not user.attended_signator_training:
-  #  template_args = {
-  #    'title' : 'Error!',
-  #    'message' : 'Error! You can not opt in to funding poll since you did not attend signators training. If you would still like to try and enter funding poll please contact the current student body treasurers to make special arrangements.',
-  #    'redirect' : '/webapps/fundingpoll',
-  #  }
-  #  return render_to_response('generic/alert-redirect.phtml', template_args, context_instance=RequestContext(request))
   
-  if fp.get_status() == DURING_R:
+  if fp.during_registration():
     def get_org(o):
       return o.organization
     fundingpoll_registered_orgs = [o for o in fp.fundingpollorganization_set.filter(funding_poll = fp, organization__signator = request.user)]
@@ -355,14 +297,10 @@ def my_registrations(request):
       'unreg_orgs' : unregistered_orgs,
     }
     
-    return render_to_response('fundingpoll/my_registrations.html', template_args, context_instance=RequestContext(request))    
+    return render(request, 'fundingpoll/my_registrations.html', template_args)    
   else:
     registered_orgs = filter(lambda x: x.organization.signator == request.user,get_top_40())
- 
-# MSK 1/30/10 commenting, not sure why this is here   
-#    if s == 'admin':
-#      registered_orgs = FundingPollOrganization.objects.filter(organization__name = "New York Times On Campus").filter(funding_poll = fp)
-    
+     
     if registered_orgs == [] and not admin:
       raise PermissionDenied
     
@@ -372,7 +310,7 @@ def my_registrations(request):
       'reg_orgs' : registered_orgs,
     }
     
-    return render_to_response('fundingpoll/my_registrations_budget.html', template_args, context_instance=RequestContext(request))
+    return render(request, 'fundingpoll/my_registrations_budget.html', template_args)
 
 def save_registration(request):
   authenticate(request, VALID_FACTORS)
@@ -383,7 +321,7 @@ def save_registration(request):
   
   fp = get_fp()
   
-  if not check_status(fp,DURING_R) and not admin:
+  if not fp.during_registration() and not admin:
     raise PermissionDenied
   
   query = demjson.decode(request.POST['query_string'])
@@ -425,9 +363,8 @@ def save_registration(request):
     'title' : 'Success!',
     'message' : 'Your organization has been registered for funding poll.',
     'redirect' : reverse('fundingpoll.views.index')
-#    'redirect' : '/webapps/fundingpoll/my_registrations',
   }
-  return render_to_response('generic/alert-redirect.phtml', template_args, context_instance=RequestContext(request))
+  return render(request, 'generic/alert-redirect.phtml', template_args)
 
 class counter(object):
   def __init__(self):
@@ -456,7 +393,7 @@ def view_all_budgets(request):
     'counter' : counter()
   }
   
-  return render_to_response('fundingpoll/view_all_budgets.html', template_args, context_instance=RequestContext(request))
+  return render(request, 'fundingpoll/view_all_budgets.html', template_args)
 
 def view_one_budget(request, budget_id):
   authenticate(request, TREASURER_FACTORS)
@@ -470,7 +407,7 @@ def view_one_budget(request, budget_id):
     'items' : items
   }
   
-  return render_to_response('fundingpoll/view_one_budget.html', template_args, context_instance=RequestContext(request))
+  return render(request, 'fundingpoll/view_one_budget.html', template_args)
 
 def view_results(request):
   authenticate(request, VALID_FACTORS)
@@ -478,7 +415,7 @@ def view_results(request):
   
   fp = get_fp()
   
-  if not check_status(fp,[DURING_B, END_B]) and not admin:
+  if not fp.after_voting() and not admin:
     raise PermissionDenied
   
   if fp.fundingpollorganization_set.all().count() > 0:
@@ -499,7 +436,7 @@ def view_results(request):
     'counter' : counter()
   }
   
-  return render_to_response('fundingpoll/results.html',template_args, context_instance=RequestContext(request))
+  return render(request, 'fundingpoll/results.html', template_args)
 
 
 def admin_view_results(request):
@@ -512,13 +449,13 @@ def admin_view_results(request):
     "counter" : counter()
   }
   
-  return render_to_response('fundingpoll/results.html',template_args, context_instance=RequestContext(request))
+  return render(request, 'fundingpoll/results.html',template_args)
 
 def preview_budget(request, budget_id):
   factor = authenticate(request, VALID_FACTORS)
-  admin = ('fundingpoll' == factor) or ('admin' == factor)
+  admin = request.user.has_factor(ADMIN_FACTORS)
   
-  if factor != 'admin':
+  if not admin:
     budget = FundingPollBudget.objects.get(organization__organization__signator = request.user, id = budget_id)
   else:
     budget = FundingPollBudget.objects.get(id = budget_id)
@@ -530,19 +467,18 @@ def preview_budget(request, budget_id):
     'items' : items
   }
   
-  return render_to_response('fundingpoll/view_one_budget.html', template_args, context_instance=RequestContext(request))
+  return render(request, 'fundingpoll/view_one_budget.html', template_args)
 
 def edit_budget(request, org_id):
   authenticate(request, VALID_FACTORS)
-  admin = request.user.has_factor(['fundingpoll', 'admin'])
-  #admin = ('fundingpoll' == factor) or ('admin' == factor)
+  admin = request.user.has_factor(ADMIN_FACTORS)
   
   if request.method != 'GET':
     raise Http404()
   
   fp = get_fp()
   
-  if not check_status(fp,[DURING_B, DURING_V]) and not admin:
+  if not fp.during_budgets() and not admin:
     raise PermissionDenied
   
   if not admin and request.user.signator_set.filter(id = org_id).count() == 0:
@@ -572,9 +508,7 @@ def edit_budget(request, org_id):
     'items' : budget_items
   }
   
-  return render_to_response('fundingpoll/edit_budget.html',
-                            template_args,
-                            context_instance=RequestContext(request))
+  return render(request, 'fundingpoll/edit_budget.html', template_args)
 
 import re
 
@@ -605,7 +539,7 @@ def save_budget(request, budget_id):
   
   fp = get_fp()
   
-  if not check_status(fp,[DURING_B, DURING_V]):
+  if not fp.during_budgets():
     raise PermissionDenied
   
   if not admin:
@@ -642,7 +576,7 @@ def save_budget(request, budget_id):
     'message' : 'Your budget has successfully been saved. You can edit it until budget editing ends at %s' % str(fp.end_budgets),
     'redirect' : url
   }
-  return render_to_response('generic/alert-redirect.phtml', template_args, context_instance=RequestContext(request))
+  return render(request, 'generic/alert-redirect.phtml', template_args)
   
 def __process_budget_post(user, budget, total_requested, dictionary, create = True):  
   organization = None

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -1,4 +1,3 @@
-
 from django.shortcuts import render, render_to_response, redirect
 from django.template import RequestContext
 from django.http import HttpResponsePermanentRedirect
@@ -213,7 +212,7 @@ def edit_org(request, org_id):
     from fundingpoll.models import FundingPoll, FundingPollOrganization, get_fp
     fp = get_fp()
     
-    if fp.get_status is not "during_registration":
+    if fp.get_status() is not "during_registration":
         fp_reg = False
 
 
@@ -299,10 +298,12 @@ def save_org(request, org_id):
     # Now if they also wanted to register for funding poll
     from fundingpoll.models import FundingPoll, FundingPollOrganization, get_fp
     fp = get_fp()
-    
-    if (fp.get_status == "during_registration" and post_dict.fp_reg):
 
-        f_org = FundingPollOrganization(organization = org,
+
+    fp_reg = post_dict.get('fp_reg') == u'on'
+    if (fp.get_status() == "during_registration" and fp_reg):
+
+        fpo = FundingPollOrganization(organization = organization,
                                         funding_poll = fp,
                                         total_votes = 0,
                                         top_six = 0,
@@ -311,10 +312,10 @@ def save_org(request, org_id):
                                         disapprove = 0,
                                         deep_six = 0)
         
-        f.org.other_signators = post_dict.get('other_signators', '')
-        f_org.comment = post_dict.get('comments', '')
+        fpo.other_signators = post_dict.get('other_signators', '')
+        fpo.comment = post_dict.get('comments', '')
 
-        f_org.save()
+        fpo.save()
         
 
     return redirect('organizations.views.my_organizations')

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -212,7 +212,7 @@ def edit_org(request, org_id):
     from fundingpoll.models import FundingPoll, FundingPollOrganization, get_fp
     fp = get_fp()
     
-    if fp.get_status() is not "during_registration":
+    if not fp.during_registration():
         fp_reg = False
 
 
@@ -301,7 +301,7 @@ def save_org(request, org_id):
 
 
     fp_reg = post_dict.get('fp_reg') == u'on'
-    if (fp.get_status() == "during_registration" and fp_reg):
+    if (fp.during_registration() and fp_reg):
 
         fpo = FundingPollOrganization(organization = organization,
                                         funding_poll = fp,

--- a/templates/fundingpoll/fundingpoll-base.html
+++ b/templates/fundingpoll/fundingpoll-base.html
@@ -9,7 +9,7 @@
 	<li class=""><a href="{% url 'fundingpoll.views.vote_main'%}"><div><b>vote</b></div></a></li>
 	<li class=""><a href="{% url 'fundingpoll.views.my_registrations'%}"><div>my reg</div></a></li>
 	<li class=""><a href="{% url 'fundingpoll.views.registered'%}"><div>reg list</div></a></li>
-	<li class=""><a href="{% url 'fundingpoll.views.schedule'%}"><div>schedule</div></a></li>	
+	<li class=""><a href="{% url 'fundingpoll.views.schedule'%}"><div>schedule</div></a></li>
 	<li class=""><a href="{% url 'fundingpoll.views.view_results'%}"><div>results</div></a></li>
 	<li class=""><a href="{% url 'fundingpoll.views.view_all_budgets'%}"><div>admin</div></a></li>
 {% endblock %}

--- a/templates/fundingpoll/schedule.html
+++ b/templates/fundingpoll/schedule.html
@@ -2,9 +2,34 @@
 
 {% block content %}
 <div class="row-extra-padding">
-	<h2>Current Status</h2> 
-	<p class="lead">{{ status }}</p>
-	<h2>Current Time</h2> 
+    <h2>Current Status</h2> 
+    <table class="table table-bordered">
+        <tr>
+            <th>Registration</th>
+            {% if reg_open %}
+            <td class="success">Open</td>
+            {% else %}
+            <td class="danger">Closed</td>
+            {% endif %}
+        </tr>
+        <tr>
+            <th>Voting</th>
+            {% if voting_open %}
+            <td class="success">Open</td>
+            {% else %}
+            <td class="danger">Closed</td>
+            {% endif %}
+        </tr>
+        <tr>
+            <th>Budgeting</th>
+            {% if budgets_open %}
+            <td class="success">Open</td>
+            {% else %}
+            <td class="danger">Closed</td>
+            {% endif %}
+        </tr>
+    </table>
+    <h2>Current Time</h2> 
 	<p class="lead">{{ time|date:"h:i:s A F d, Y" }}</p>
 </div>
 <div class="row">

--- a/templates/fundingpoll/schedule.html
+++ b/templates/fundingpoll/schedule.html
@@ -5,12 +5,20 @@
     <h2>Current Status</h2> 
     <table class="table table-bordered">
         <tr>
+            <th>Stage</th>
+            <th>Status</th>
+            <th>Start Time</th>
+            <th>End Time</th>
+        </tr>
+        <tr>
             <th>Registration</th>
             {% if reg_open %}
             <td class="success">Open</td>
             {% else %}
             <td class="danger">Closed</td>
             {% endif %}
+            <td>{{ fp.start_registration|date:"h:i:s A F d, Y" }}</td>
+            <td>{{ fp.end_registration|date:"h:i:s A F d, Y" }}</td>
         </tr>
         <tr>
             <th>Voting</th>
@@ -19,6 +27,8 @@
             {% else %}
             <td class="danger">Closed</td>
             {% endif %}
+            <td>{{ fp.start_voting|date:"h:i:s A F d, Y" }}</td>
+            <td>{{ fp.end_voting|date:"h:i:s A F d, Y" }}</td>
         </tr>
         <tr>
             <th>Budgeting</th>
@@ -27,62 +37,12 @@
             {% else %}
             <td class="danger">Closed</td>
             {% endif %}
+            <td>{{ fp.start_budgets|date:"h:i:s A F d, Y" }}</td>
+            <td>{{ fp.end_budgets|date:"h:i:s A F d, Y" }}</td>
         </tr>
     </table>
     <h2>Current Time</h2> 
 	<p class="lead">{{ time|date:"h:i:s A F d, Y" }}</p>
 </div>
-<div class="row">
-	<h2>Current Schedule</h2>
-	<table class="table table-hover">
-	<tr>
-	<td>
-	Organization Registration Start: 
-	</td>
-	<td>
-	{{ fp.start_registration|date:"h:i:s A F d, Y" }}
-	</td>
-	</tr>
-	<tr>
-	<td>
-	Organization Registration End: 
-	</td>
-	<td>
-	{{ fp.end_registration|date:"h:i:s A F d, Y" }}
-	</td>
-	</tr>
-	<tr>
-	<td>
-	Voting Start: 
-	</td>
-	<td>
-	{{ fp.start_voting|date:"h:i:s A F d, Y" }}
-	</td>
-	</tr>
-	<tr>
-	<td>
-	Voting End: 
-	</td>
-	<td>
-	{{ fp.end_voting|date:"h:i:s A F d, Y" }}
-	</td>
-	</tr>
-	<tr>
-	<td>
-	Budget Submission Start: 
-	</td>
-	<td>
-	{{ fp.start_budgets|date:"h:i:s A F d, Y" }}
-	</td>
-	</tr>
-	<tr>
-	<td>
-	Budget Submission End: 
-	</td>
-	<td>
-	{{ fp.end_budgets|date:"h:i:s A F d, Y" }}
-	</td>
-	</tr>
-	</table>
-</div>
+
 {% endblock %}

--- a/templates/organizations/edit_org.html
+++ b/templates/organizations/edit_org.html
@@ -142,7 +142,7 @@ function validate(form) {
   </div>
   <div class="col-lg-9 col-md-8 col-sm-8">
    <div class="table-responsive">
-    <table class="table table-hover hidden">
+    <table id="fp-reg-form" class="table table-hover hidden">
       <tr><td>
 	<label for="other_signators">Other Signators</label>
 	<input class="form-control" id="other_signators"
@@ -177,9 +177,12 @@ function validate(form) {
 <script>
 // Enable the fields for Funding Poll registration when check box is checked
 $('#fp_reg').click(function() {
-    $('#other_signators').attr('disabled', !$(this).attr('checked'));
-    $('#comment-text-area').attr('disabled', !$(this).attr('checked'));
+  console.log(this.checked);
+    $('#fp-reg-form').toggleClass('hidden');
+    $('#other_signators').attr('disabled', !this.checked);
+    $('#comment-text-area').attr('disabled', !this.checked);
 });
+
 </script>
 
 {% endblock %}


### PR DESCRIPTION
# Funding Poll

I changed the interface for Funding Poll times. They now use methods
- `during_registration`
- `during_voting`
- `after_voting`
- `during_budgets`

to determine what stage a Funding Poll is in. This helps readability of code and allows more flexibility in how Funding Polls are structured, including allowing stages to overlap. 

The Funding Poll views were cleaned up significantly, including switching from `render_to_response` to `render` method for each view. 

Finally, the Funding Polls schedule page is now a color coded table showing status of each stage individually.
# New Org page

An often-requested feature: the new organization creation page also has a section for registering for funding poll at the same time.
