### PR TITLE
Integrate Bugsnag for exception reporting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,15 @@
+bugsnag==2.4.0
 demjson==2.2.2
 dj-database-url==0.3.0
 dj-static==0.0.6
 Django==1.7.3
+django-crispy-forms==1.6.0
 django-toolbelt==0.0.1
 gunicorn==19.1.1
 psycopg2==2.5.4
 python-ldap==2.4.0
 pytz==2015.2
+six==1.10.0
 static3==0.5.1
-django-crispy-forms==1.6.0
+WebOb==1.6.0
+wheel==0.29.0

--- a/webapps2/example_settings.py
+++ b/webapps2/example_settings.py
@@ -53,6 +53,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'bugsnag.django.middleware.BugsnagMiddleware'
 )
 
 ROOT_URLCONF = 'webapps2.urls'
@@ -107,3 +108,6 @@ SERVER_EMAIL = 'noreply@sin.reed.edu'
 # )
 TEMPLATE_DIRS = [os.path.join(BASE_DIR, 'templates')]
 
+BUGSNAG = {
+    "api_key": "put the real API key here"
+}


### PR DESCRIPTION
We currently send emails to the admins every time an exception is triggered, which is very convenient. [Bugsnag](https://bugsnag.com/) is a service that offers even more sophisticated reporting of exceptions.

The service groups similar exceptions, captures information about the user, parses stack traces, integrates well with services like Slack (as well as email), and allows efficient triage and discussion of exceptions. I've used it before with great success.

I contacted Bugsnag and they set us up with a free open source plan. The integration in production requires placing the correct secret Bugsnag API key in the `settings.py` file. For now we can do this manually, but we may want to consider how we manage our various secret keys in the future. 

Some steps to take after merging:

1. Give access to Will and Alex
2. Set up Slack integration

cc @wjones127. We can talk about this when we meet—just a heads up!